### PR TITLE
pdfa flag no generate + destravar suite no Rack 3

### DIFF
--- a/lib/rasper_client/client.rb
+++ b/lib/rasper_client/client.rb
@@ -37,7 +37,7 @@ module RasperClient
 
     def execute_request(action, options)
       response = Net::HTTP.start(*build_request_params) do |http|
-        request = Net::HTTP::Post.new(uri_for(action))
+        request = Net::HTTP::Post.new("#{@path_prefix}/#{action}")
         request.body = options.to_json
         request.basic_auth(@username, @password) if @username && @password
         http.request(request)
@@ -92,20 +92,6 @@ module RasperClient
           hash[key] = '' if hash[key].nil?
         end
       end
-    end
-
-    def uri_for(action)
-      uri_build_class
-        .build(
-          host: @host,
-          port: @port,
-          path: "#{@path_prefix}/#{action}"
-        )
-        .to_s
-    end
-
-    def uri_build_class
-      @secure ? URI::HTTPS : URI::HTTP
     end
 
     def check_for_errors(response)

--- a/lib/rasper_client/client.rb
+++ b/lib/rasper_client/client.rb
@@ -54,7 +54,7 @@ module RasperClient
     end
 
     def symbolize_keys(options)
-      %w(name content images report data parameters).each do |s|
+      %w(name content images report data parameters pdfa).each do |s|
         symbolize_key(options, s)
       end
       if options[:images]
@@ -79,7 +79,10 @@ module RasperClient
     end
 
     def encode_data(options)
-      { data: Base64.encode64(options.to_json) }
+      pdfa = options.delete(:pdfa)
+      body = { data: Base64.encode64(options.to_json) }
+      body[:pdfa] = pdfa if pdfa
+      body
     end
 
     def empty_nil_values(hash)

--- a/lib/rasper_client/fake_server.rb
+++ b/lib/rasper_client/fake_server.rb
@@ -2,7 +2,7 @@ require 'sinatra/base'
 require 'json'
 require 'base64'
 
-Rack::Utils.key_space_limit = 262144
+Rack::Utils.key_space_limit = 262144 if Rack::Utils.respond_to?(:key_space_limit=)
 
 module RasperClient
   class FakeServer
@@ -35,12 +35,14 @@ module RasperClient
 
         post '/add' do
           content_type :json
+          request.body.rewind
           FakeServer.last_added_report = JSON.parse(request.body.read)
           { success: true }.to_json
         end
 
         post '/generate' do
           content_type :json
+          request.body.rewind
           FakeServer.last_generated_report =
             JSON.parse(Base64.decode64(JSON.parse(request.body.read)['data']))
           { content: Base64.encode64(File.read(resource('dummy.pdf'))) }.to_json

--- a/lib/rasper_client/fake_server.rb
+++ b/lib/rasper_client/fake_server.rb
@@ -7,7 +7,7 @@ Rack::Utils.key_space_limit = 262144 if Rack::Utils.respond_to?(:key_space_limit
 module RasperClient
   class FakeServer
     class << self
-      attr_accessor :last_added_report, :last_generated_report
+      attr_accessor :last_added_report, :last_generated_report, :last_generate_pdfa
     end
 
     def start(port, username, password)
@@ -43,8 +43,9 @@ module RasperClient
         post '/generate' do
           content_type :json
           request.body.rewind
-          FakeServer.last_generated_report =
-            JSON.parse(Base64.decode64(JSON.parse(request.body.read)['data']))
+          body = JSON.parse(request.body.read)
+          FakeServer.last_generate_pdfa = body['pdfa']
+          FakeServer.last_generated_report = JSON.parse(Base64.decode64(body['data']))
           { content: Base64.encode64(File.read(resource('dummy.pdf'))) }.to_json
         end
       end

--- a/rasper_client.gemspec
+++ b/rasper_client.gemspec
@@ -23,5 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'sinatra'
+  gem.add_development_dependency 'rackup'
+  gem.add_development_dependency 'puma'
   gem.add_development_dependency 'pry-rails'
 end

--- a/spec/rasper_client_spec.rb
+++ b/spec/rasper_client_spec.rb
@@ -108,7 +108,7 @@ describe RasperClient do
     it 'allows pass a timeout to client' do
       expect(Net::HTTP).to \
         receive(:start).
-        with('localhost', port, read_timeout: 100).
+        with('localhost', port, { read_timeout: 100 }).
         and_return(double(body: '{"success":true}', code: '200'))
       client.add(name: 'programmers', content: jrxml_content)
     end

--- a/spec/rasper_client_spec.rb
+++ b/spec/rasper_client_spec.rb
@@ -103,6 +103,17 @@ describe RasperClient do
       }
   end
 
+  it 'sends pdfa as a top-level field, outside the encoded data' do
+    client.generate(
+      name: 'programmers',
+      data: [{ name: 'Linus', software: 'Linux' }],
+      parameters: {},
+      pdfa: '1b'
+    )
+    expect(RasperClient::FakeServer.last_generate_pdfa).to eq '1b'
+    expect(RasperClient::FakeServer.last_generated_report).not_to have_key('pdfa')
+  end
+
   context 'timeout' do
     let(:timeout) { 100 }
     it 'allows pass a timeout to client' do


### PR DESCRIPTION
Envia o flag \`pdfa\` (ex. \`'1b'\`) como campo **top-level** do request \`generate\` (irmão de \`data\`, fora do payload codificado), para o rasper ligar o export PDF/A. Traz também o commit da net-http e destrava o suite de testes no Rack 3.

## Commits
1. **Pass only path to the method class** — commit já existente na branch net-http.
2. **fix: destravar suite no Rack 3** — o suite do FakeServer estava totalmente vermelho no Rack 3.2.6: guard do \`Rack::Utils.key_space_limit=\` (removido no Rack 3), \`rackup\`/\`puma\` como dev deps (Sinatra 4 precisa de handler), \`request.body.rewind\` antes de ler o corpo, e fix de kwargs no teste de timeout. Suite volta a **9/9 verde**.
3. **feat: pdfa top-level** — \`generate\` hoista \`:pdfa\` pro top-level (\`encode_data\`); \`fake_server\` reflete via \`last_generate_pdfa\`; teste no \`rasper_client_spec.rb\` via FakeServer.

Contrato: ausência de \`pdfa\` = comportamento atual (PDF comum) intacto.